### PR TITLE
Custom Targeting

### DIFF
--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -5,7 +5,7 @@ import {
   findNodeHandle,
   ViewPropTypes,
 } from 'react-native';
-import { string, func, arrayOf } from 'prop-types';
+import { string, func, arrayOf, object } from 'prop-types';
 
 import { createErrorFromErrorData } from './utils';
 
@@ -97,6 +97,11 @@ PublisherBanner.propTypes = {
    * DFP ad unit ID
    */
   adUnitID: string,
+
+  /**
+   * Custom targeting for DFP Banners
+   */
+  customTargeting: object,
 
   /**
    * Array of test devices. Use PublisherBanner.simulatorId for the simulator

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 		A96DA77E1C146D7200FC639B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../ios/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
@@ -267,7 +267,7 @@
 		A96DA77F1C146D7200FC639B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../ios/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, copy) NSArray *validAdSizes;
 @property (nonatomic, copy) NSArray *testDevices;
+@property (nonatomic, copy) NSDictionary *customTargeting;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -53,8 +53,11 @@
 #pragma clang diagnostic pop
 
 - (void)loadBanner {
-    GADRequest *request = [GADRequest request];
+    DFPRequest *request = [DFPRequest request];
     request.testDevices = _testDevices;
+    if (_customTargeting != nil) {
+        request.customTargeting = _customTargeting;
+    }
     [_bannerView loadRequest:request];
 }
 
@@ -75,6 +78,13 @@
 - (void)setTestDevices:(NSArray *)testDevices
 {
     _testDevices = RNAdMobProcessTestDevices(testDevices, kDFPSimulatorID);
+}
+
+- (void)setCustomTargeting:(NSDictionary *)customTargeting
+{
+    if (![customTargeting isEqual:_customTargeting]) {
+        _customTargeting = customTargeting;
+    }
 }
 
 -(void)layoutSubviews

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -36,6 +36,7 @@ RCT_REMAP_VIEW_PROPERTY(adSize, _bannerView.adSize, GADAdSize)
 RCT_REMAP_VIEW_PROPERTY(adUnitID, _bannerView.adUnitID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(customTargeting, NSDictionary);
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-admob",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0",
   "description": "A react-native component for Google AdMob banners and interstitials",
   "author": "Simon Bugert <simon.bugert@gmail.com>",
   "main": "index.js",


### PR DESCRIPTION
- Updated to upstream master
- Cherry picked the necessary changes in

Just comparing against master see we can see a clear diff - I think we should actually force push over the `bam` branch once this is approved.

Fun fact: With the new version of RNAdMob, we need to supply the `validAdSizes` prop, otherwise you won't see anything on iOS!